### PR TITLE
Move test dependencies to the demo app so they don't interfere with apps that use the gem

### DIFF
--- a/lib/cybersourcery.rb
+++ b/lib/cybersourcery.rb
@@ -15,16 +15,6 @@ if defined? Rails
   require 'cybersourcery/reason_code_checker'
   require 'cybersourcery/container'
   require 'cybersourcery/cybersource_params_normalizer'
-
-  if Rails.env.test?
-    require 'slim-rails'
-    require 'bootstrap-sass'
-    require 'simple_form'
-    require 'sass-rails'
-    require 'coffee-rails'
-    require 'jquery-rails'
-    require 'dotenv-rails'
-  end
 end
 
 module Cybersourcery

--- a/spec/demo/config/application.rb
+++ b/spec/demo/config/application.rb
@@ -7,6 +7,14 @@ require "action_mailer/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
+require 'slim-rails'
+require 'bootstrap-sass'
+require 'simple_form'
+require 'sass-rails'
+require 'coffee-rails'
+require 'jquery-rails'
+require 'dotenv-rails'
+
 Bundler.require(*Rails.groups)
 
 # For a typical rails app this line is not needed.


### PR DESCRIPTION
@toppa This change modifies the demo app. I don't remember if the demo app needs to be updated or not.
